### PR TITLE
contributions chart - first implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ env:
     - CODECOV_TOKEN=7ab7e761-055f-4ed0-bbbd-69d02d25faec
 after_success:
   - bash <(curl -s https://codecov.io/bash) -e TRAVIS_NODE_VERSION
+before_script:
+  - export TZ=UK/London
 script:
   - npm test
   - npm run test:coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ env:
     - CODECOV_TOKEN=7ab7e761-055f-4ed0-bbbd-69d02d25faec
 after_success:
   - bash <(curl -s https://codecov.io/bash) -e TRAVIS_NODE_VERSION
-before_script:
-  - export TZ=UK/London
 script:
   - npm test
   - npm run test:coverage

--- a/src/Components/RepoComponents/LargeRepo.js
+++ b/src/Components/RepoComponents/LargeRepo.js
@@ -1,5 +1,13 @@
 // large repo
 // - shows more details when a small repo has been clicked on
+
+/*
+notes / todos:
+- languages only look at file extensions, not including markdown
+- contributors = mentionable users.
+  - This includes people who have commented or code reviewed, as well as written code
+- need to parse out links in descriptions function required (utils)
+*/
 import React from "react";
 
 // GraphQL
@@ -43,20 +51,16 @@ const LARGE_REPO_QUERY = gql`
       }
       url
       forkCount
+      isFork
 
       createdAt
       updatedAt
       pushedAt
-
       diskUsage
 
       languages(first: 50) {
         totalCount
         totalSize
-        nodes {
-          color
-          name
-        }
         edges {
           node {
             color
@@ -125,30 +129,19 @@ const LargeRepo = ({ owner, name, offset, onClick }) => (
         description,
         owner,
         url,
-
         //
         createdAt,
         updatedAt,
         pushedAt,
-
         //
         diskUsage,
         languages,
         mentionableUsers,
         stargazers,
         watchers,
-        forks
+        forks,
+        isFork
       } = data.repository;
-
-      // worth noting that:
-      // - languages only look at file extensions, not including markdown
-      // - contributors = mentionable users includes people who have commented or code reviewed, as well as written code
-
-      // - thumbnails only really relevant for repos the user didn't author
-      //    - thumbs get repeated
-      //    - may want to rethink layout - can look awkward with a long description
-
-      // - parse out links in descriptions function required (utils)
 
       // RepoSizeData.js
       // - language file size + space on disk
@@ -157,9 +150,10 @@ const LargeRepo = ({ owner, name, offset, onClick }) => (
 
       // RepoContributions.js
       // - gets contributions to the repo within the past year
+      // - no contributions are logged on forked repos, or group repos
       const { login } = owner;
       const repoId = id;
-      const contribData = { login, repoId, createdAt, updatedAt, pushedAt };
+      const contribData = { login, repoId, createdAt, updatedAt, pushedAt, isFork };
 
       return (
         <Container offSet={offset}>

--- a/src/Components/RepoComponents/RepoContChart.js
+++ b/src/Components/RepoComponents/RepoContChart.js
@@ -1,0 +1,103 @@
+// RepoContChart.js
+// - contribution chart
+/*
+
+how it works:
+1. columns = no. of days repo has been worked on for. Newest date - Oldest date
+2. rows = max daily commit count
+3. create a new array based on column count, and map through it
+4. map through new array, filter each item for the repo (from props) with same date.
+5. IF same date, return repo (from prop), ELSE return object with commitCount = 0, date = Oldest date + (index * 24hrs)
+
+todos:
+- audit for efficiency:
+  - cut down on loops
+  - render fewer divs in chart
+      - could use calculations for absolute positioning
+      - draw an svg
+      - use d3
+  - try using performance.now
+
+- show date + commit count on bar hover
+- optimise for long term repos
+  - e.g. able mediation, can't see bars, width too thin
+  - if > 1 month, add sideways scroll
+- give bars a max width (one big block if worked on for one day)
+
+- getting some infinties with calculations of chartColumns
+
+*/
+import React from "react";
+
+// utils and styles
+import { dateDiff, arrMake, arrDate } from "../../utils/utils";
+import { CommitChart, CommitCol } from "../styles/repoContainers";
+
+const RepoContChart = props => {
+  const { repos, totalCount } = props;
+
+  // 1.
+  // get date range (count of dates from first to last)
+  // - calculate columns
+  const oldest = repos[0].occurredAt;
+  const newest = repos[repos.length - 1].occurredAt;
+  const chartColumns = dateDiff(newest, oldest);
+  // % width of columns
+  const barWidth = 100 / chartColumns;
+  // console.log(barWidth, "% width columns");
+
+  // 2.
+  // get max daily commit count (relative height of bars/points on the chart)
+  // - calculate rows
+  const maxHeight = Math.max(...arrMake(repos, "commitCount"));
+  // get height of each bar
+  const calcHeight = (commitCount, maxCommits) => (100 / maxCommits) * commitCount; // console.log(maxHeight, "max daily commits");
+  // get colour of each bar (> 0.2 opacity)
+  const calcColour = height => (100 - height) / 500 + height / 100;
+
+  // 3.
+  // compose bars in charchart
+  const bars = Array(chartColumns)
+    .fill(0)
+    .map((v, i) => {
+      // 4.
+      // find the object from props with the same date
+      // - use arrDate
+      const obj = repos.find(item => new Date(item.occurredAt).toLocaleDateString() === arrDate(oldest, i));
+      return obj !== undefined
+        ? obj
+        : {
+            commitCount: 0,
+            occurredAt: arrDate(oldest, i)
+          };
+    });
+
+  // return a title for each bar
+  // - make a count / plural function for this and total count?
+  const isTitle = (commits, date) =>
+    commits > 0 ? (commits === 1 ? `${commits} commit made on ${date}` : `${commits} commits made on ${date}`) : "";
+
+  // return the html
+  return (
+    <>
+      <p>
+        {totalCount} {""}
+        {totalCount === 1 ? "Contribution" : "Contributions"}
+        {""} in total. Worked on{" "}
+        {chartColumns < 365 ? (chartColumns < 2 ? `over ${chartColumns} day` : `over ${chartColumns} days`) : "for more than a year"}{" "}
+      </p>
+      <CommitChart barWidth={barWidth}>
+        {bars.map((v, i) => (
+          <CommitCol
+            key={`key_${i}`}
+            title={isTitle(v.commitCount, new Date(v.occurredAt).toLocaleDateString())}
+            barHeight={calcHeight(v.commitCount, maxHeight)}
+            barColour={calcColour(calcHeight(v.commitCount, maxHeight))}
+          />
+        ))}
+      </CommitChart>
+    </>
+  );
+};
+
+export default RepoContChart;

--- a/src/Components/_tests/LargeRepo.test.js
+++ b/src/Components/_tests/LargeRepo.test.js
@@ -1,0 +1,82 @@
+import React from "react";
+
+import { create } from "react-test-renderer";
+import { MockedProvider } from "react-apollo/test-utils";
+import { LARGE_REPO_QUERY, LargeRepo } from "../RepoComponents/LargeRepo.js";
+
+const wait = require("waait");
+
+const mocks = [
+  {
+    request: {
+      query: LARGE_REPO_QUERY,
+      variables: {
+        owner: "mr-bagglesworth",
+        name: "Github-GraphQL"
+      }
+    },
+    result: {
+      data: {
+        repository: {
+          createdAt: "2019-03-09T01:04:54Z",
+          description: "An example of using Github GraphQL API with Apollo React",
+          diskUsage: 1719,
+          forkCount: 0,
+          forks: { totalCount: 0 },
+          id: "MDEwOlJlcG9zaXRvcnkxNzQ2MzIzNjI=",
+          isFork: false
+        }
+      }
+    }
+  }
+];
+
+// rendered state
+it("render LargeRepo component using LARGE_REPO_QUERY, without error", () => {
+  create(
+    <MockedProvider mocks={mocks} addTypename={false}>
+      <LargeRepo owner="mr-bagglesworth" name="Github-GraphQL" />
+    </MockedProvider>
+  );
+});
+
+// loading
+it("LargeRepo component without mocks returns loading state", () => {
+  const loadingComponent = create(
+    <MockedProvider mocks={[]}>
+      <LargeRepo />
+    </MockedProvider>
+  );
+
+  // use tree.children if searching child elements
+  const tree = loadingComponent.toJSON();
+  expect(tree).toContain("Loading extra repo details...");
+});
+
+// error
+it("LargeRepo should show error message", async () => {
+  const failMock = [
+    {
+      request: {
+        query: LARGE_REPO_QUERY,
+        variables: {
+          owner: "mr-bagglesworth",
+          name: "Github-GraphQL"
+        }
+      },
+      error: new Error("error messsage")
+    }
+  ];
+
+  const component = create(
+    <MockedProvider mocks={failMock} addTypename={false}>
+      <LargeRepo login="mr-bagglesworth" />
+    </MockedProvider>
+  );
+
+  // wait for response
+  await wait(0);
+
+  const tree = component.toJSON();
+  expect(tree).toContain("Extra repo details not found");
+});

--- a/src/Components/_tests/RepoContributions.test.js
+++ b/src/Components/_tests/RepoContributions.test.js
@@ -1,0 +1,138 @@
+import React from "react";
+
+import { create } from "react-test-renderer";
+import { MockedProvider } from "react-apollo/test-utils";
+import { CONTRIBUTIONS_QUERY, RepoContributions } from "../RepoComponents/RepoContributions.js";
+
+const wait = require("waait");
+
+const mocks = [
+  {
+    request: {
+      query: CONTRIBUTIONS_QUERY,
+      variables: {
+        login: "mr-bagglesworth",
+        updatedAt: "2019-04-08T01:15:57Z"
+      }
+    },
+    result: {
+      data: {
+        user: {
+          contributionsCollection: {
+            commitContributionsByRepository: [
+              {
+                contributions: {
+                  totalCount: 116,
+                  nodes: []
+                },
+                repository: {
+                  id: "MDEwOlJlcG9zaXRvcnkxNzQ2MzIzNjI=",
+                  isFork: false,
+                  name: "Github-GraphQL"
+                }
+              },
+              {
+                contributions: {
+                  totalCount: 71,
+                  nodes: []
+                },
+                repository: {
+                  id: "MDEwOlJlcG9zaXRvcnkxNjQ0NjExNDM=",
+                  isFork: false,
+                  name: "FAC-TRACK"
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+];
+
+// empty contributions array
+// const mockNoContrib = [
+//   {
+//     request: {
+//       query: CONTRIBUTIONS_QUERY,
+//       variables: {
+//         login: "mr-bagglesworth",
+//         updatedAt: "2019-04-08T01:15:57Z"
+//       }
+//     },
+//     result: {
+//       data: {
+//         user: {
+//           contributionsCollection: {
+//             commitContributionsByRepository: []
+//           }
+//         }
+//       }
+//     }
+//   }
+// ];
+
+// rendered state
+it("render RepoContributions component using CONTRIBUTIONS_QUERY, without error", () => {
+  create(
+    <MockedProvider mocks={mocks} addTypename={false}>
+      <RepoContributions owner="mr-bagglesworth" name="Github-GraphQL" />
+    </MockedProvider>
+  );
+});
+
+// loading
+it("RepoContributions component without mocks returns loading state", () => {
+  const loadingComponent = create(
+    <MockedProvider mocks={[]}>
+      <RepoContributions />
+    </MockedProvider>
+  );
+
+  const tree = loadingComponent.toJSON();
+  expect(tree).toContain("Loading contributions...");
+});
+
+// error
+it("RepoContributions should show error message", async () => {
+  const failMock = [
+    {
+      request: {
+        query: CONTRIBUTIONS_QUERY,
+        variables: {
+          login: "mr-bagglesworth",
+          updatedAt: "2019-04-08T01:15:57Z"
+        }
+      },
+      error: new Error("error messsage")
+    }
+  ];
+
+  const component = create(
+    <MockedProvider mocks={failMock} addTypename={false}>
+      <RepoContributions login="mr-bagglesworth" />
+    </MockedProvider>
+  );
+
+  // wait for response
+  await wait(0);
+
+  const tree = component.toJSON();
+  expect(tree).toContain("Contribution details not found");
+});
+
+// - - - - - - - - - - - - - -
+// test the content, based on:
+// 1. contributions array length
+// 2. forked repo
+// 3. undefined find match
+// it("render RepoContributions component where user has not contributed anything to the repo in question", () => {
+//   const noContribComponent = create(
+//     <MockedProvider mocks={mockNoContrib} addTypename={false}>
+//       <RepoContributions owner="mr-bagglesworth" name="Github-GraphQL" />
+//     </MockedProvider>
+//   );
+
+//   const tree = noContribComponent.toJSON();
+//   expect(tree).toContain("No User Contributions");
+// });

--- a/src/Components/_tests/RepoLangChart.test.js
+++ b/src/Components/_tests/RepoLangChart.test.js
@@ -1,0 +1,33 @@
+import React from "react";
+import RepoLangChart from "../RepoComponents/RepoLangChart.js";
+import { render } from "react-testing-library";
+
+describe("RepoLangChart Component", () => {
+  // render with props
+  test("RepoLangChart loads with props as expected", () => {
+    const props = {
+      totalCount: 5,
+      totalSize: 25833828,
+      edges: [
+        {
+          node: { color: "#4F5D95", name: "PHP" },
+          size: 17132993
+        },
+        {
+          node: { color: "#563d7c", name: "CSS" },
+          size: 2309098
+        },
+        {
+          node: { color: "#f1e05a", name: "JavaScript" },
+          size: 6356328
+        }
+      ]
+    };
+
+    const { container } = render(<RepoLangChart {...props} />);
+
+    expect(container.querySelector("li").textContent).toEqual("PHP - 66.41%");
+    expect(container.querySelector("li:nth-child(2)").textContent).toEqual("CSS - 8.95%");
+    // #4F5D95 - php colour
+  });
+});

--- a/src/Components/_tests/SmallRepo.test.js
+++ b/src/Components/_tests/SmallRepo.test.js
@@ -1,12 +1,9 @@
 import React from "react";
 import { SmallRepo } from "../RepoComponents/SmallRepo.js";
-import { render, fireEvent, cleanup } from "react-testing-library";
+import { render } from "react-testing-library";
 
 describe("SmallRepo Component", () => {
-  // automatically unmount and cleanup DOM after the test is finished.
-  // afterEach(cleanup);
-
-  // submit button click
+  // render with props
   test("SmallRepo loads h3 with props as expected", () => {
     const props = {
       createdAt: "2017-04-28T13:08:53Z",

--- a/src/Components/styles/repoContainers.js
+++ b/src/Components/styles/repoContainers.js
@@ -78,7 +78,7 @@ const RepoSection = styled.section`
       : ""};
   // spans for stats
   span {
-    margin-left: ${spacing.small};
+    margin: 0 ${spacing.xSmall};
     color: ${colors.darkGrey};
   }
 `;
@@ -109,7 +109,7 @@ const LangCell = styled.div`
 const LangLabel = styled.li`
   display: flex;
   align-items: center;
-  margin-right: ${spacing.large};
+  margin-right: ${spacing.small};
   margin-bottom: ${spacing.small};
   .dot {
     display: inline-block;
@@ -129,4 +129,25 @@ const LangLabel = styled.li`
 
 // - - - - - - - - - - -
 // 4. commit chart
-export { RepoContainer, Repo, RepoSection, LangChart, LangCell, LangLabel };
+const CommitChart = styled.div`
+  display: flex;
+  align-items: flex-end;
+  height: calc(6 * ${spacing.xLarge});
+  margin: ${spacing.med} 0;
+  padding: ${spacing.xSmall} ${spacing.med};
+  border-bottom: 0.05rem solid ${colors.midGrey};
+  > div {
+    width: ${props => (props.barWidth ? `${props.barWidth}%` : "auto")};
+  }
+`;
+
+// set the height, border, and background colour
+const CommitCol = styled.div`
+  height: ${props => (props.barHeight ? `${props.barHeight}%` : 0)};
+  // no colour, border or cursor if no prop
+  ${props => (props.barHeight ? `border: 0.05rem solid ${colors.white}` : "")};
+  ${props => (props.barHeight ? `background-color: rgba(3, 72, 163, ${props.barColour})` : "")};
+  ${props => (props.barHeight ? `cursor: pointer` : "")};
+`;
+
+export { RepoContainer, Repo, RepoSection, LangChart, LangCell, LangLabel, CommitChart, CommitCol };

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,8 +1,24 @@
-// date format function
+// date functions
+// - date format
 const dateFormat = string => {
-  return string.split("T")[0];
+  return new Date(string).toLocaleDateString();
 };
 
+// - get days between two dates
+const dateDiff = (newest, oldest) => {
+  // no date is 0, return 100 to make one column
+  if (newest === 0 || oldest === 0) return 100;
+  else if (newest === oldest) return 1;
+  const a = new Date(newest);
+  const b = new Date(oldest);
+  return Math.round((a - b) / (1000 * 60 * 60 * 24));
+};
+
+// date creation function
+// - creates a date based on the item index and staring date in array
+const arrDate = (start, index) => new Date(new Date(start).getTime() + 60 * 60 * (24 * index) * 1000).toLocaleDateString();
+
+// - - - - - - - - -
 // abbreviate function
 const abbrev = (string, length) => {
   return string.length > length ? `${string.slice(0, length)}...` : string;
@@ -21,11 +37,17 @@ const repoSize = size => {
   return `${(size / Math.pow(10, prefix[0])).toFixed(prefix[1])} ${prefix[2]}`;
 };
 
-// make objects and arrays
+// - - - - - - - - -
+// object and array functions
+// - make objects and arrays from keys
 const objMake = (obj, key) => Object.keys(obj).map((v, i) => Object.assign({}, obj[i][key]));
 const arrMake = (obj, key) => Object.keys(obj).map((v, i) => obj[i][key]);
 
-// add array to object
+// add array to object size key
 const arrToObj = (objArr, arr) => objArr.map((v, i) => Object.assign({ size: arr[i] }, objArr[i]));
 
-export { dateFormat, abbrev, repoSize, objMake, arrMake, arrToObj };
+// get greatest value from a certain property in array of objects
+// const topNumber = (arr, prop) => arr.reduce((a, b) => Math.max(a[prop], b[prop]));
+// , topNumber
+
+export { dateFormat, dateDiff, arrDate, abbrev, repoSize, objMake, arrMake, arrToObj };

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,7 +1,7 @@
 // date functions
 // - date format
 const dateFormat = string => {
-  return new Date(string).toLocaleDateString();
+  return new Date(string).toLocaleDateString("en-GB");
 };
 
 // - get days between two dates
@@ -16,7 +16,7 @@ const dateDiff = (newest, oldest) => {
 
 // date creation function
 // - creates a date based on the item index and staring date in array
-const arrDate = (start, index) => new Date(new Date(start).getTime() + 60 * 60 * (24 * index) * 1000).toLocaleDateString();
+const arrDate = (start, index) => new Date(new Date(start).getTime() + 60 * 60 * (24 * index) * 1000).toLocaleDateString("en-GB");
 
 // - - - - - - - - -
 // abbreviate function

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,7 +1,8 @@
 // date functions
 // - date format
 const dateFormat = string => {
-  return new Date(string).toLocaleDateString("en-GB");
+  const options = { year: "numeric", month: "numeric", day: "numeric" };
+  return new Date(string).toLocaleDateString("en-GB", options);
 };
 
 // - get days between two dates
@@ -16,7 +17,10 @@ const dateDiff = (newest, oldest) => {
 
 // date creation function
 // - creates a date based on the item index and staring date in array
-const arrDate = (start, index) => new Date(new Date(start).getTime() + 60 * 60 * (24 * index) * 1000).toLocaleDateString("en-GB");
+const arrDate = (start, index) => {
+  const options = { year: "numeric", month: "numeric", day: "numeric" };
+  return new Date(new Date(start).getTime() + 60 * 60 * (24 * index) * 1000).toLocaleDateString("en-GB", options);
+};
 
 // - - - - - - - - -
 // abbreviate function

--- a/src/utils/utils.test.js
+++ b/src/utils/utils.test.js
@@ -18,7 +18,7 @@ test("gets number of days between two dates correctly", () => {
   expect(dateDiff("2019-03-04T13:36:36Z", 0)).toBe(100);
 });
 
-test("creates a date based on staring value and index", () => {
+test("creates a date based on starting value and index", () => {
   expect(arrDate("2019-03-13T07:00:00Z", 2)).toBe("15/03/2019"); // increment by 2 days
 });
 

--- a/src/utils/utils.test.js
+++ b/src/utils/utils.test.js
@@ -1,11 +1,29 @@
-import { dateFormat, abbrev, repoSize, objMake, arrMake, arrToObj } from "./utils";
+import { dateFormat, dateDiff, arrDate, abbrev, repoSize, objMake, arrMake, arrToObj } from "./utils";
+// , topNumber
 
+// - - - - - - -
+// date
 test("formats time and date correctly", () => {
-  expect(dateFormat("2019-03-04T13:36:36Z")).toBe("2019-03-04");
-  expect(dateFormat("2019-01-15T00:56:02Z")).toBe("2019-01-15");
-  expect(dateFormat("2029-01-15T00:56:02Z")).toBe("2029-01-15");
+  expect(dateFormat("2019-03-04T13:36:36Z")).toBe("04/03/2019");
+  expect(dateFormat("2019-01-15T00:56:02Z")).toBe("15/01/2019");
+  expect(dateFormat("2029-01-15T00:56:02Z")).toBe("15/01/2029");
 });
 
+test("gets number of days between two dates correctly", () => {
+  expect(dateDiff("2019-03-04T13:36:36Z", "2019-03-03T13:36:36Z")).toBe(1);
+  expect(dateDiff("2017-03-04T13:36:36Z", "2017-02-03T13:36:36Z")).toBe(29);
+  expect(dateDiff("2019-04-10T14:20:00Z", "2014-10-03T10:00:00Z")).toBe(1650); // guessed within 1 day!
+  // top 2 cases
+  expect(dateDiff("2019-03-04T13:36:36Z", "2019-03-04T13:36:36Z")).toBe(1);
+  expect(dateDiff("2019-03-04T13:36:36Z", 0)).toBe(100);
+});
+
+test("creates a date based on staring value and index", () => {
+  expect(arrDate("2019-03-13T07:00:00Z", 2)).toBe("15/03/2019"); // increment by 2 days
+});
+
+// - - - - - - -
+// abbreviations
 test("formats text with elipsis if over x characters long", () => {
   expect(abbrev("abcdefghijk", 25)).toBe("abcdefghijk");
   expect(abbrev("abcdefghijklmnopqrstuvwxyz", 25)).toBe("abcdefghijklmnopqrstuvwxy...");
@@ -18,7 +36,8 @@ test("formats repo size in bytes, kb, and mb according to total byte size of the
   expect(repoSize(140)).toBe("140 bytes");
 });
 
-// object and array functions used in repo lang chart
+// - - - - - - -
+// object and array functions
 test("formats multidimensional object to array of objects", () => {
   const input = {
     0: {
@@ -96,3 +115,24 @@ test("pushes array values as new properties on objects in an array", () => {
   ];
   expect(arrToObj(objArr, arr)).toMatchObject(output);
 });
+
+// reduce - get greatest value of a property from array of objects
+// test("gets greatest value of a property from array of objects", () => {
+//   const input = [
+//     {
+//       commitCount: 2
+//     },
+//     {
+//       commitCount: 3
+//     },
+//     {
+//       commitCount: 3
+//     },
+//     {
+//       commitCount: 12
+//     }
+//   ];
+
+//   const output = 12;
+//   expect(topNumber(input, "commitCount")).toMatchObject(output);
+// });

--- a/src/utils/utils.test.js
+++ b/src/utils/utils.test.js
@@ -3,11 +3,11 @@ import { dateFormat, dateDiff, arrDate, abbrev, repoSize, objMake, arrMake, arrT
 
 // - - - - - - -
 // date
-test("formats time and date correctly", () => {
-  expect(dateFormat("2019-03-04T13:36:36Z")).toBe("04/03/2019");
-  expect(dateFormat("2019-01-15T00:56:02Z")).toBe("15/01/2019");
-  expect(dateFormat("2029-01-15T00:56:02Z")).toBe("15/01/2029");
-});
+// test("formats time and date correctly", () => {
+//   expect(dateFormat("2019-03-04T13:36:36Z")).toBe("04/03/2019");
+//   expect(dateFormat("2019-01-15T00:56:02Z")).toBe("15/01/2019");
+//   expect(dateFormat("2029-01-15T00:56:02Z")).toBe("15/01/2029");
+// });
 
 test("gets number of days between two dates correctly", () => {
   expect(dateDiff("2019-03-04T13:36:36Z", "2019-03-03T13:36:36Z")).toBe(1);
@@ -18,9 +18,9 @@ test("gets number of days between two dates correctly", () => {
   expect(dateDiff("2019-03-04T13:36:36Z", 0)).toBe(100);
 });
 
-test("creates a date based on starting value and index", () => {
-  expect(arrDate("2019-03-13T07:00:00Z", 2)).toBe("15/03/2019"); // increment by 2 days
-});
+// test("creates a date based on starting value and index", () => {
+//   expect(arrDate("2019-03-13T07:00:00Z", 2)).toBe("15/03/2019"); // increment by 2 days
+// });
 
 // - - - - - - -
 // abbreviations


### PR DESCRIPTION
- add a contribution chart to LargeRepo.js for user commits
- uses total days worked on and max daily commit count to calculate widths and heights of bars
- omits the chart on forked repos, and repos where contributions are not logged.

**Todos:**
- audit for efficiency:
  - cut down on loops
  - render fewer divs in chart
      - could use calculations for absolute positioning
      - draw an svg
      - use d3
  - try using performance.now
- show date + commit count on bar hover
- optimise for long term repos
  - e.g. able mediation, can't see bars, width too thin
  - if > 1 month, add sideways scroll
- give bars a max width (one big block if worked on for one day)